### PR TITLE
Squash bug/fix-spiderfied-state-on-update-layers

### DIFF
--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -108,6 +108,8 @@ L.MarkerCluster.include({
 				delete m._spiderLeg;
 			}
 		}
+
+        this._group._spiderfied = null;
 	}
 });
 

--- a/src/MarkerCluster.Spiderfier.js
+++ b/src/MarkerCluster.Spiderfier.js
@@ -109,7 +109,7 @@ L.MarkerCluster.include({
 			}
 		}
 
-        this._group._spiderfied = null;
+		this._group._spiderfied = null;
 	}
 });
 


### PR DESCRIPTION
Added the deletion of the current `_spiderfied` MarkerCluster on `_noanimationUnspiderfy()`.

If this is not done and `spiderfy` or `noanimationSpiderfy` are called afterwards, these methods will try to `unspiderfy` the current `_spiderfied` MarkerCluster. That results in javascript errors and the functionality to spiderfy MarkerCluster's is broken until the next page reload.


This caused two bugs in the DiLoc - pimap app:

**1) Use the "Toggle Trains/Stations" button while MarkerCluster is spiderfied**

Steps to reproduce:
1. Hover over a MarkerCluster to make it spiderfied
2. Toggle trains or stations
3. Hover over the same MarkerCluster => Makes the icons disappear
4. Hover over a different MarkerCluster => Error triggered

*Example*
![error_1_example_1](https://user-images.githubusercontent.com/30892746/62610750-8c845000-b904-11e9-8174-68cad1d6c743.gif)


**2) Data refresh**

Steps to reproduce:
1. Hover over a MarkerCluster to make it spiderfied
2. Wait for a data refresh (icons disappear for a short moment)
3. Hover over a different MarkerCluster => Error triggered

This one also happens when you are viewing a dialog of a Marker inside a spiderfied MarkerCluster, e.g. the departure list.

*Example*
![error_2_example_2](https://user-images.githubusercontent.com/30892746/62612582-f2260b80-b907-11e9-9198-266aadc1bb24.gif)


**Test done**

* Ran `jake build[d,spiderextend]` to generate the dist version of this library
* Replaced the library of the pimap app with the updated version
* Checked that the errors no longer occur

*Toggle buttons error fixed*
![error_1_fixed](https://user-images.githubusercontent.com/30892746/62613230-59908b00-b909-11e9-899b-10701f69ce41.gif)


*Data Refresh error fixed*
![error_2_fixed](https://user-images.githubusercontent.com/30892746/62613096-13d3c280-b909-11e9-9619-246558f9225c.gif)


**Squash Message**

```
Added the deletion of the current `_spiderfied` MarkerCluster on `_noanimationUnspiderfy()`.

If this is not done and `spiderfy` or `noanimationSpiderfy` are called afterwards, these methods will try to `unspiderfy` the current `_spiderfied` MarkerCluster. That results in javascript errors and the functionality to spiderfy MarkerCluster's is broken until the next page reload.
```